### PR TITLE
Different insert format

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ To insert the clock into the selection, you can either click on the clock on sta
 * Bring up Command Palette (`F1`, or `Ctrl+Shift+P` on Windows and Linux, or `Shift+CMD+P` on OSX)
 * Type or select "Clock: Insert date and time"
 
+The date time format that is used when inserting into selection can be changed via preferences
+* File > Preferences > User Settings
+* Adds the following line
+  *	```"clock.insertFormat": "dd/mm/yyyy hh:MM TT"```
+  * Date format can be found at https://github.com/felixge/node-dateformat
+
 You can also modify keyboard shortcut with JSON below.
 ```
 {
@@ -27,6 +33,7 @@ You can also modify keyboard shortcut with JSON below.
 
 ## Change log
 * 0.0.1 (2016-02-24): First public release
+* 0.1.0 (2017-08-01): Separate insert format than that shown in the clock
 
 ## Contributions
 Love this extension? [Star](https://github.com/compulim/vscode-clock/stargazers) us!

--- a/clockservice.js
+++ b/clockservice.js
@@ -1,11 +1,18 @@
 'use strict';
 
 const
-  dateformat = require('dateformat'),
-  vscode = require('vscode');
+    dateformat = require('dateformat'),
+    vscode = require('vscode');
 
 const DEFAULT_DATE_FORMAT = 'hh:MM TT';
+const DEFAULT_INSERT_FORMAT = 'dd/mm/yyyy hh:MM TT';
 
-module.exports = function () {
-  return dateformat(Date.now(), vscode.workspace.getConfiguration('clock').dateFormat || DEFAULT_DATE_FORMAT);
+module.exports = {
+    insert: function() {
+        return dateformat(Date.now(), vscode.workspace.getConfiguration('clock').insertFormat || DEFAULT_INSERT_FORMAT);
+    },
+
+    show: function() {
+        return dateformat(Date.now(), vscode.workspace.getConfiguration('clock').dateFormat || DEFAULT_DATE_FORMAT);
+    }
 };

--- a/clockstatusbaritem.js
+++ b/clockstatusbaritem.js
@@ -1,32 +1,30 @@
 'use strict';
 
 const
-  clockService = require('./clockservice'),
-  dateformat = require('dateformat'),
-  vscode = require('vscode');
-
-const DEFAULT_DATE_FORMAT = 'hh:MM TT';
+    clockService = require('./clockservice'),
+    dateformat = require('dateformat'),
+    vscode = require('vscode');
 
 class StatusBarItem {
-  constructor() {
-    this._statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, -100);
-    this._statusBarItem.command = 'clock.insertDateTime';
-    this._statusBarItem.tooltip = 'Click to insert into selection';
-    this._statusBarItem.show();
+    constructor() {
+        this._statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, -100);
+        this._statusBarItem.command = 'clock.insertDateTime';
+        this._statusBarItem.tooltip = 'Click to insert into selection';
+        this._statusBarItem.show();
 
-    this._interval = setInterval(() => this.refreshUI(), 1000);
+        this._interval = setInterval(() => this.refreshUI(), 1000);
 
-    this.refreshUI();
-  }
+        this.refreshUI();
+    }
 
-  dispose() {
-    this._statusBarItem.dispose();
-    clearInterval(this._interval);
-  }
+    dispose() {
+        this._statusBarItem.dispose();
+        clearInterval(this._interval);
+    }
 
-  refreshUI() {
-    this._statusBarItem.text = clockService();
-  }
+    refreshUI() {
+        this._statusBarItem.text = clockService.show();
+    }
 }
 
 module.exports = StatusBarItem;

--- a/extension.js
+++ b/extension.js
@@ -3,40 +3,39 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 const
-  clockService = require('./clockservice'),
-  ClockStatusBarItem = require('./clockstatusbaritem'),
-  vscode = require('vscode');
+    clockService = require('./clockservice'),
+    ClockStatusBarItem = require('./clockstatusbaritem'),
+    vscode = require('vscode');
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 function activate(context) {
-  // Use the console to output diagnostic information (console.log) and errors (console.error)
-  // This line of code will only be executed once when your extension is activated
+    // Use the console to output diagnostic information (console.log) and errors (console.error)
+    // This line of code will only be executed once when your extension is activated
 
-  // The command has been defined in the package.json file
-  // Now provide the implementation of the command with  registerCommand
-  // The commandId parameter must match the command field in package.json
-  context.subscriptions.push(new ClockStatusBarItem());
+    // The command has been defined in the package.json file
+    // Now provide the implementation of the command with  registerCommand
+    // The commandId parameter must match the command field in package.json
+    context.subscriptions.push(new ClockStatusBarItem());
 
-  context.subscriptions.push(vscode.commands.registerTextEditorCommand('clock.insertDateTime', (textEditor, edit) => {
-    textEditor.selections.forEach(selection => {
-      const
-        start = selection.start,
-        end = selection.end;
+    context.subscriptions.push(vscode.commands.registerTextEditorCommand('clock.insertDateTime', (textEditor, edit) => {
+        textEditor.selections.forEach(selection => {
+            const
+                start = selection.start,
+                end = selection.end;
 
-      if (start.line === end.line && start.character === end.character) {
-        edit.insert(start, clockService());
-      } else {
-        edit.replace(selection, clockService());
-      }
-    });
-  }));
+            if (start.line === end.line && start.character === end.character) {
+                edit.insert(start, clockService.insert());
+            } else {
+                edit.replace(selection, clockService.insert());
+            }
+        });
+    }));
 }
 
 exports.activate = activate;
 
 // this method is called when your extension is deactivated
-function deactivate() {
-}
+function deactivate() {}
 
 exports.deactivate = deactivate;

--- a/package.json
+++ b/package.json
@@ -1,53 +1,58 @@
 {
-  "name": "vscode-clock",
-  "displayName": "Clock",
-  "description": "Displays clock in status bar and insert into file",
-  "version": "0.0.1",
-  "publisher": "Compulim",
-  "engines": {
-    "vscode": "^0.10.1"
-  },
-  "icon": "icon.png",
-  "galleryBanner.color": "#0D5CAB",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/compulim/vscode-clock.git"
-  },
-  "bugs": "https://github.com/compulim/vscode-clock/issues/",
-  "homepage": "https://github.com/compulim/vscode-clock/blob/master/README.md",
-  "keywords": [
-    "clock",
-    "timer",
-    "alarm"
-  ],
-  "categories": [
-    "Other"
-  ],
-  "activationEvents": [
-    "*"
-  ],
-  "main": "./extension",
-  "contributes": {
-    "commands": [{
-      "command": "clock.insertDateTime",
-      "title": "Clock: Insert date and time"
-    }],
-    "configuration": {
-      "type": "object",
-      "title": "Clock configuration",
-      "properties": {
-        "clock.dateFormat": {
-          "type": "string",
-          "default": "hh:MM TT",
-          "description": "Clock: Date format according to https://github.com/felixge/node-dateformat"
+    "name": "vscode-clock",
+    "displayName": "Clock",
+    "description": "Displays clock in status bar and insert into file",
+    "version": "0.1.0",
+    "publisher": "Compulim",
+    "engines": {
+        "vscode": "^0.10.1"
+    },
+    "icon": "icon.png",
+    "galleryBanner.color": "#0D5CAB",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/compulim/vscode-clock.git"
+    },
+    "bugs": "https://github.com/compulim/vscode-clock/issues/",
+    "homepage": "https://github.com/compulim/vscode-clock/blob/master/README.md",
+    "keywords": [
+        "clock",
+        "timer",
+        "alarm"
+    ],
+    "categories": [
+        "Other"
+    ],
+    "activationEvents": [
+        "*"
+    ],
+    "main": "./extension",
+    "contributes": {
+        "commands": [{
+            "command": "clock.insertDateTime",
+            "title": "Clock: Insert date and time"
+        }],
+        "configuration": {
+            "type": "object",
+            "title": "Clock configuration",
+            "properties": {
+                "clock.insertFormat": {
+                    "type": "string",
+                    "default": "dd/mm/yyyy hh:MM TT",
+                    "description": "Clock: Date format according to https://github.com/felixge/node-dateformat"
+                },
+                "clock.dateFormat": {
+                    "type": "string",
+                    "default": "hh:MM TT",
+                    "description": "Clock: Date format according to https://github.com/felixge/node-dateformat"
+                }
+            }
         }
-      }
+    },
+    "devDependencies": {
+        "vscode": "0.11.x"
+    },
+    "dependencies": {
+        "dateformat": "^1.0.12"
     }
-  },
-  "devDependencies": {
-    "vscode": "0.11.x"
-  },
-  "dependencies": {
-    "dateformat": "^1.0.12"
-  }
 }


### PR DESCRIPTION
This **PR** adds the next feature: *make insertion of clock have a different format string configuration*. This way you can visualize time in clock bar, while still inserting full date and time into documents.

I would rather have this feature into your VSCode extension, instead of publishing a different extension myself. Kindly ask you to merge this commit into your master. 